### PR TITLE
Use eventually with a large timeout in cnbi controller test

### DIFF
--- a/controllers/cnbi/controller_test.go
+++ b/controllers/cnbi/controller_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 10
-	duration = time.Second * 10
+	timeout  = time.Second * 40
 	interval = time.Millisecond * 750
 )
 
@@ -61,18 +60,17 @@ var _ = Describe("CustomNBImage controller", func() {
 				Status: meteorv1alpha1.CustomNotebookImageStatus{},
 			}
 			Expect(k8sClient.Create(context.Background(), cnbi)).Should(Succeed())
-			time.Sleep(20 * time.Second) // FIXME 👻 smells like a race condition, please increase the timeout for slow clusters
 
 			lookupKey := types.NamespacedName{Name: "test-1", Namespace: "default"}
-			createdCNBi := &meteorv1alpha1.CustomNBImage{}
 
-			Consistently(func() bool {
+			Eventually(func(g Gomega) {
+				createdCNBi := &meteorv1alpha1.CustomNBImage{}
 				err := k8sClient.Get(ctx, lookupKey, createdCNBi)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(createdCNBi.Status.Conditions).ToNot(BeEmpty())
+				g.Expect(createdCNBi.Status.Phase).To(Equal(meteorv1alpha1.PhaseRunning))
+			}, timeout, interval).Should(Succeed())
 
-			Expect(createdCNBi.Status.Conditions).ShouldNot(BeEmpty())
-			Expect(createdCNBi.Status.Phase).Should(Equal(meteorv1alpha1.PhaseRunning))
 		})
 	})
 	/*


### PR DESCRIPTION
We increase the test timeout to avoid test flakes depending on hardware. To avoid running the test for the duration of the timeout each time we use Eventually (https://onsi.github.io/gomega/#eventually)